### PR TITLE
Input Compontent for Long and Lat

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -1,10 +1,16 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import LongLatTest from './components/LongLatTest';
 
 class App extends Component {
   render() {
     console.log(this.props.currentUser);
-    return <h1>Hello STUMAT!!!</h1>;
+    return (
+      <div>
+        <h1>Hello STUMAT!!!</h1>
+        <LongLatTest />
+      </div>
+    )
   }
 }
 

--- a/client/components/LongLatTest.jsx
+++ b/client/components/LongLatTest.jsx
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import Form from './common/Form';
+
+class LongLatTest extends Form {
+  /*
+    It's most helpful to initiate your state with names of your form fields.
+    These object properties will be populated with field input data based one
+    name and instantiating them in your state with empty strings avoids a 
+    "controlled Component" warning from React
+  */
+  state = {
+    data: {
+      longitute: '',
+      latitude: '',
+    },
+  }
+
+  doSubmit = () => {
+    console.log('Submitted:', this.state.data)
+  }
+
+  render() {
+    return (
+      <div className="formContainer">
+        <h1>Long Lat Test Form</h1>
+        <form onSubmit={this.handleSubmit}> {/*Inherits this from Form component*/}
+          <h5>Coordinates</h5>
+          <div className="row">
+            <div className="col">
+              {this.renderInput('longitute', 'Enter Long:', 'text', 'Enter Long coords')}
+            </div>
+            <div className="col">
+              {this.renderInput('latitude', 'Enter Lat:', 'text', 'Enter Lat coords')}
+            </div>
+          </div>
+          <div>
+            {this.renderButton('Submit', 'btnClass')}
+          </div>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default LongLatTest;

--- a/client/components/common/Form.jsx
+++ b/client/components/common/Form.jsx
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import Input from './Input';
+
+/*
+This component doesn't directly render anything. It's a wrapper component
+for any other component that you want to use a form. Any of the form elements
+you choose to render via the functions included will be sharing the same
+component state via inheritance.
+ie: component Banana extends Form.
+In Banana you render two inputs and a select. 
+The state referred to in Form is inherited from Banana and therefore
+your two inputs and select are all using Banana's state to track their values.
+*/
+
+class Form extends Component {
+  // Any child of this class (ie: Banana) must have data in its state.
+  state = {
+    data: {},
+  }
+
+  /*
+   Will update local state with user input for the field passed on the 
+   event object to this function. The value for the field will be given
+   a property on state.data that is associated with the name attribute given 
+   to the field via props when the field is created.
+   ie: <input name='bananaSplit' /> value will be at state.data.bananaSplit
+   */
+  handleChange = ({ currentTarget: input }) => {
+    const data = { ...this.state.data };
+    data[input.name] = input.value;
+    this.setState({ data });
+  };
+
+  // Any child of this component (ie: Banana) must have a doSubmit method
+  handleSubmit = eventObj => {
+    eventObj.preventDefault();
+    this.doSubmit();
+  };
+
+  // Optional fields for form. Call these functions in your child component
+  renderInput(name, label, type = 'text', placeholder, instructions) {
+    const { data } = this.state;
+    return (<Input
+      name={name}
+      label={label}
+      onChange={this.handleChange}
+      type={type}
+      instructions={instructions}
+      value={data[name]}
+      placeholder={placeholder}
+    />)
+  };
+
+  renderButton(label, classString) {
+    return (
+      <button
+        className={classString}>
+        {label}
+      </button>
+    )
+  }
+};
+
+
+export default Form;

--- a/client/components/common/Input.jsx
+++ b/client/components/common/Input.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Input = ({
+  name,
+  label,
+  onChange,
+  instructions,
+  type,
+  value,
+  placeholder,
+}) => {
+  return (
+    <div className="formField">
+      <label htmlFor={name}>{label}</label>
+      <input
+        name={name}
+        id={name}
+        onChange={onChange}
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        className="inputField"
+      />
+      {instructions && <div>{instructions}</div>}
+    </div>
+  );
+};
+
+Input.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  instructions: PropTypes.string,
+  type: PropTypes.string,
+  value: PropTypes.any,
+  placeholder: PropTypes.string,
+};
+
+export default Input;

--- a/client/index.css
+++ b/client/index.css
@@ -1,3 +1,3 @@
 * {
-  background-color: blue;
+  background-color: white;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/StumatStudio/Healthyhood#readme",
   "devDependencies": {
     "@babel/core": "^7.10.2",
+    "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@babel/plugin-transform-runtime": "^7.10.1",
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
@@ -60,6 +61,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -29,10 +29,14 @@ module.exports = {
           loader: 'babel-loader',
           options: {
             presets: ['@babel/preset-env', '@babel/preset-react'],
-            plugins: ['@babel/plugin-transform-runtime'],
+            plugins: ['@babel/plugin-transform-runtime', '@babel/plugin-proposal-class-properties'],
           },
         },
       },
     ],
+  },
+  resolve: {
+    // Allows importing JS / JSX files without specifying extension
+    extensions: ['.js', '.jsx'],
   },
 };


### PR DESCRIPTION
**webpack.common and package.json**
Added @babel/plugin-proposal-class-properties as plugin after installing as dev dependency. Allows transpiling of newer react syntax. Also added react-prop-types as package to avoid linting errors from not defining prop types in react components. 

**client/components/common/Form.jsx**
A reusable form component designed to be a parent class of any component that needs a form. Currently contains a method for rendering inputs and buttons.

**client/components/common/Input.jsx**
A reusable input component. It uses specific props to configure itself. Tightly coupled with the common Form component for use in app components that need data entry from the user. 

**client/components/LongLatTest.jsx**
A child component to the Form component. This is a temporary component designed to allow for the longitude and latitude data entry as proof of concept. 

**client/App.js**
Altered to render the LongLatTest component to the screen.

**client/index.css**
Changed background from blue to white so I could see the text.