### PR TITLE
Integrate with Walkscore API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6933,6 +6933,11 @@
         "tslib": "^1.10.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mongoose": "^5.9.18",
+    "node-fetch": "^2.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",

--- a/server/controllers/walkScoreController.js
+++ b/server/controllers/walkScoreController.js
@@ -1,0 +1,36 @@
+const fetch = require('node-fetch');
+const walkScoreController = {};
+
+walkScoreController.getWalkScore = (req, res, next) => {
+  console.log('Invoked walkScoreController.getWalkScore', req.query);
+  const { lat, lon } = req.query;
+  fetch(
+    `https://api.walkscore.com/score?format=json&lat=${lat}&lon=${lon}&transit=1&bike=1&wsapikey=${process.env.WALKSCORE_KEY}`,
+    {
+      method: 'GET',
+      redirect: 'follow',
+    }
+  )
+    .then(response => {
+      // console.log('response', response.status, response.statusText);
+      res.statusCode = response.status;
+      res.statusMessage = response.statusText;
+      return response.json();
+    })
+    .then(data => {
+      // console.log('walkScore data', data);
+      // console.log('res', res.statusCode, res.statusMessage);
+      res.locals.walkscore = data;
+      return next();
+    })
+    .catch(error =>
+      next({
+        message: 'Error in walkScoreController.getWalkScore middleware',
+        serverMessage: {
+          err: error,
+        },
+      })
+    );
+};
+
+module.exports = walkScoreController;

--- a/server/controllers/walkScoreController.js
+++ b/server/controllers/walkScoreController.js
@@ -1,6 +1,13 @@
 const fetch = require('node-fetch');
 const walkScoreController = {};
 
+// getWalkScore will fetch the Walk Score for a given location
+// Required request parameters:
+//    lat: the latitude of the location
+//    lon: the longitude of the location
+//    address: URL encoded address (seems to work without this)
+// Further information on other parameters and response:
+// https://www.walkscore.com/professional/api.php
 walkScoreController.getWalkScore = (req, res, next) => {
   console.log('Invoked walkScoreController.getWalkScore', req.query);
   const { lat, lon } = req.query;

--- a/server/controllers/walkScoreController.js
+++ b/server/controllers/walkScoreController.js
@@ -10,14 +10,14 @@ const walkScoreController = {};
 // https://www.walkscore.com/professional/api.php
 walkScoreController.getWalkScore = (req, res, next) => {
   console.log('Invoked walkScoreController.getWalkScore', req.query);
-  const { lat, lon } = req.query;
-  fetch(
-    `https://api.walkscore.com/score?format=json&lat=${lat}&lon=${lon}&transit=1&bike=1&wsapikey=${process.env.WALKSCORE_KEY}`,
-    {
-      method: 'GET',
-      redirect: 'follow',
-    }
-  )
+  const { lat, lon, address } = req.query;
+  const API_URL = 'https://api.walkscore.com/score';
+  const params = `format=json&transit=1&bike=1&wsapikey=${process.env.WALKSCORE_KEY}`;
+  const URL = `${API_URL}?${params}&lat=${lat}&lon=${lon}&address=${address}`;
+  fetch(URL, {
+    method: 'GET',
+    redirect: 'follow',
+  })
     .then(response => {
       // console.log('response', response.status, response.statusText);
       res.statusCode = response.status;

--- a/server/routes/walkScore.js
+++ b/server/routes/walkScore.js
@@ -10,6 +10,10 @@ router.get('/', walkScoreController.getWalkScore, (req, res) => {
   //  res.statusMessage = status message
   //  res.locals.walkscore = status code
   console.log('router.get / walkscore', res.locals.walkscore);
+
+  // currently returning the entire blob of data to the client
+  // should consider reducing this to what is actually needed:
+  // https://www.walkscore.com/professional/api.php
   res.status(res.statusCode).send(res.locals.walkscore);
 });
 

--- a/server/routes/walkScore.js
+++ b/server/routes/walkScore.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const walkScoreController = require('../controllers/walkScoreController');
+
+const router = express.Router();
+
+router.get('/', walkScoreController.getWalkScore, (req, res) => {
+  // on success, res.locals.walkscore will contain the Walk Score json blob
+  // on error:
+  //  res.statusCode = http response
+  //  res.statusMessage = status message
+  //  res.locals.walkscore = status code
+  console.log('router.get / walkscore', res.locals.walkscore);
+  res.status(res.statusCode).send(res.locals.walkscore);
+});
+
+module.exports = router;

--- a/server/startup/routes.js
+++ b/server/startup/routes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 
 const users = require('../routes/users');
+const walkScore = require('../routes/walkScore');
 
 const baseUrl = process.env.BASE_URL;
 
@@ -13,6 +14,7 @@ all of the routes within to the app object passed in
 module.exports = app => {
   // Traditional Routes
   app.use(`${baseUrl}/users`, users);
+  app.use(`${baseUrl}/walkscore`, walkScore);
 
   // Static files
   if (process.env.NODE_ENV !== 'development') {


### PR DESCRIPTION
**package.json**
- Installs node-fetch for server-side fetching

**server/startup/routes.js**
- Updates the routes to include the walkscore route

**server/routes/walkScore.js**
- Implements a single `GET` request to `/{base_url}/walkscore`
- This will fetch the Walk Score data blob from the Walk Score API
- The entire data blob is sent to the client.  We should review what we actually want to send within that blob

**server/controllers/walkScoreController.js**
- `walkScoreController.getWalkScore`: this will make a `GET` request to the Walk Score API
- It needs in the `req.query` object these properties, at a minimum:
`{ lat: <latitude>, lon: <longitude> }`
- There is an `address` parameter that the API states it needs but I've run some tests without it and it still worked.  We should determine what we actually want to send to the API based on the location data from the user
- There are other parameters I've hardcoded for now to also obtain the Bike Score and Transit Score, but we can omit those if we don't end up using it.

**Installation**
- Run `npm install` to install the node-fetch package

**Testing**
- Make a GET request to http://localhost:3000/{base_url}/walkscore and set the lat / lon parameters.  Example:
`http://localhost:3000/{base_url}/walkscore?lat=47.6085&lon=-122.3295`
