### PR TITLE
add iqAir route and controller

### DIFF
--- a/server/controllers/iqAirController.js
+++ b/server/controllers/iqAirController.js
@@ -1,0 +1,45 @@
+const fetch = require('node-fetch');
+const iqAirController = {};
+
+// getIqAirScore will fetch the IQ Air Quality for a given location
+// Required request parameters:
+//    lat: the latitude of the location
+//    lon: the longitude of the location
+// If lat/lon are not provided, the API will attempt to use
+// IP Geolocation to determine location
+//
+// Further information on other parameters and response:
+// https://www.walkscore.com/professional/api.php
+iqAirController.getIqAirScore = (req, res, next) => {
+  console.log('Invoked iqAirController.getIqAirScore', req.query);
+  const { lat, lon } = req.query;
+  const API_URL = 'https://api.airvisual.com/v2/nearest_city';
+  const params = `key=${process.env.IQAIR_KEY}`;
+  const URL = `${API_URL}?${params}&lat=${lat}&lon=${lon}`;
+  fetch(URL, {
+    method: 'GET',
+    redirect: 'follow',
+  })
+    .then(response => {
+      // console.log('response', response.status, response.statusText);
+      res.statusCode = response.status;
+      res.statusMessage = response.statusText;
+      return response.json();
+    })
+    .then(data => {
+      // console.log('iqAirScore data', data);
+      // console.log('res', res.statusCode, res.statusMessage);
+      res.locals.iqairscore = data;
+      return next();
+    })
+    .catch(error =>
+      next({
+        message: 'Error in iqAirController.getIqAirScore middleware',
+        serverMessage: {
+          err: error,
+        },
+      })
+    );
+};
+
+module.exports = iqAirController;

--- a/server/routes/iqAir.js
+++ b/server/routes/iqAir.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const iqAirController = require('../controllers/iqAirController');
+
+const router = express.Router();
+
+router.get('/', iqAirController.getIqAirScore, (req, res) => {
+  // on success, res.locals.iqairscore will contain the IQ Air json blob
+  console.log('router.get / iqairscore', res.locals.iqairscore);
+
+  // currently returning the entire blob of data to the client
+  // should consider reducing this to what is actually needed:
+  // https://api-docs.airvisual.com/?version=latest
+  res.status(200).send(res.locals.iqairscore);
+});
+
+module.exports = router;

--- a/server/startup/routes.js
+++ b/server/startup/routes.js
@@ -4,6 +4,7 @@ const path = require('path');
 const users = require('../routes/users');
 const walkScore = require('../routes/walkScore');
 const yelp = require('../routes/yelp');
+const iqAir = require('../routes/iqAir');
 
 const baseUrl = process.env.BASE_URL;
 
@@ -17,6 +18,7 @@ module.exports = app => {
   app.use(`${baseUrl}/users`, users);
   app.use(`${baseUrl}/walkscore`, walkScore);
   app.use(`${baseUrl}/yelp`, yelp);
+  app.use(`${baseUrl}/iqair`, iqAir);
 
   // app.get(`${baseUrl}/nope`, (req, res) => {
   //   res.status(200).json({ message: 'YOU DID IT!!' });


### PR DESCRIPTION
**server/startup/routes.js**
- Adds a route for the iqAir API (https://api-docs.airvisual.com/?version=latest)
- The path will be `/{base_url}/iqair`

**server/routes/iqAir.js**
- Adds a route for a single `GET` request to fetch the IQ Air data

**server/controllers/iqAirController.js**
- Implements `iqAirController.getIqAirScore` to fetch the IQ Air data
- The request needs to include the latitude and longitude of the form `?lat=<latittude>&lon=<longitude>`
- It will return the IQ Air data in `res.locals.iqair`, specifically the `aqius` property is what we want to display to the user and used in the algorithm to calculate the Healthyhood score.
`{"status":"success","data":{"city":"Culver City","state":"California","country":"USA","location":{"type":"Point","coordinates":[-118.406339,34.020148]},"current":{"weather":{"ts":"2020-06-19T01:00:00.000Z","tp":19,"pr":1013,"hu":68,"ws":3.73,"wd":235,"ic":"01d"},"pollution":{"ts":"2020-06-19T01:00:00.000Z","aqius":27,"mainus":"p2","aqicn":9,"maincn":"p2"}}}}`

**Testing**
- Perform a `GET` request like the following:
`http://localhost:3000/api/iqair?lon=-118.389375&lat=34.032828`