### PR TITLE
Health Score computed!

### DIFF
--- a/client/components/experimental/LongLatTest.jsx
+++ b/client/components/experimental/LongLatTest.jsx
@@ -25,11 +25,15 @@ class LongLatTest extends Form {
     const { getYelpData, getWalkData, getIqAirData, getHealthScore, updateUserLocation } = this.props;
     updateUserLocation(this.state.data)
 
-    const secretSauce = await Promise.all([
-      getYelpData(this.state.data),
-      getWalkData(this.state.data),
-      getIqAirData(this.state.data),
-    ]);
+    try {
+      const secretSauce = await Promise.all([
+        getYelpData(this.state.data),
+        getWalkData(this.state.data),
+        getIqAirData(this.state.data),
+      ]);
+    } catch (e) {
+      console.log(e.message);
+    }
 
     const { yelpData, walkData, iqAirData } = this.props.map;
     const { restaurants, gyms } = yelpData;
@@ -38,7 +42,7 @@ class LongLatTest extends Form {
       yelpGyms: gyms.total,
       yelpRestaurants: restaurants.total,
       walkScore: walkData.walkscore,
-      iqairscore: iqAirData.data.current.pollution.aqius
+      iqAirScore: iqAirData.data.current.pollution.aqius
     }
 
     getHealthScore(secretSauceObj);

--- a/client/store/entities/mapEntity.js
+++ b/client/store/entities/mapEntity.js
@@ -113,6 +113,7 @@ function iqAirDataReceivedCase(state, action) {
 }
 
 function healthScoreReceivedCase(state, action) {
+  console.log('health payload', action.payload);
   const { data: healthScore } = action.payload;
   state.healthScore = healthScore;
   state.healthComputed = true;
@@ -126,7 +127,7 @@ const { apiCallRequested } = apiActions;
 const yelpDataUrl = 'yelp/business/search';
 const walkDataUrl = '/walkscore';
 const iqAirUrl = '/iqair';
-const healthScoreUrl = '/nope';
+const healthScoreUrl = '/healthyscore';
 
 export const getYelpData = latLongObj => {
   const { lat, lng } = latLongObj;
@@ -168,13 +169,13 @@ export const getIqAirData = latLonObj => {
 
 export const getHealthScore = secretSauceObj => {
   const { walkScore, yelpGyms, yelpRestaurants, iqAirScore } = secretSauceObj;
-  const newUrl = `${iqAirUrl}?walkscore=${walkScore}&yelpgyms=${yelpGyms}&yelprestaurants=${yelpRestaurants}&iqairscore=${iqAirScore}`;
+  const newUrl = `${healthScoreUrl}?walkscore=${walkScore}&yelpgyms=${yelpGyms}&yelprestaurants=${yelpRestaurants}&iqairscore=${iqAirScore}`;
   return apiCallRequested({
-    url: healthScoreUrl,
+    url: newUrl,
     method: 'get',
     data: '',
     onStart: DATA_REQUEST,
-    onSuccess: IQAIR_DATA_RECEIVED,
+    onSuccess: HEALTH_SCORE_RECEIVED,
     onError: DATA_REQUEST_FAILED,
   });
 };

--- a/client/store/middleware/apiCall.js
+++ b/client/store/middleware/apiCall.js
@@ -51,11 +51,14 @@ const apiCall = ({ dispatch, getState }) => next => async action => {
     // For Dev Tools to track success
     dispatch(apiCallSuccess(response.data)); // axios returns an object with a data prop
 
-    // Pass succcessful resonse data to slice success action for updating state
+    // On successful API call dispatch action labeled as the success action passing response data as payload
     if (onSuccess)
-      dispatch({
+      return dispatch({
         type: onSuccess,
-        payload: { data: response.data, headers: response.headers },
+        payload: {
+          data: response.data,
+          headers: response.headers,
+        },
       });
   } catch (err) {
     // For Dev tools / displaying error to client


### PR DESCRIPTION
**client…/LongLatTest**
-Added conditional rendering for healthScore
-Cleaned up syntax for importing action creators (destructured from props)
-Enclosed action calls into a promise.all to ensure completion before return
-Added action dispatch for computing healthScore

***Error handling NOT FINISHED in doSubmit***

**store…/mapEntity**
-Cleaned up initial yelpDataState
-Added fields for healthComputer (facilitates conditional Render) and healthScore
-Added actions to update state on healthScore received from server and when a batch
API call is started
-Updated comments on payloads so they’re more accurate in action creators section
-Added groupAPIcall case which resets healthScore related state on batchApi call start
-Oi, those Date.nows in the yelp, walk, and iq reducer cases should be gone. They’re left over from the ton of code I deleted when we discovered promise.all works in redux
-Added healthScore received case which updates state for conditional render and healthScore
-Added action generator for calling server to get health score

**store…/apiCall**
-Cleaned up some syntax and added a return statement to dispatch to ensure frontend could consume promise