### PR TITLE
add google maps route and controller

### DIFF
--- a/client/store/entities/mapEntity.js
+++ b/client/store/entities/mapEntity.js
@@ -17,7 +17,6 @@ const getInitialLocation = () => {
 };
 
 const initialState = {
-
   yelpData: {},
   walkData: {},
   iqAirData: {},

--- a/server/controllers/googleMapsController.js
+++ b/server/controllers/googleMapsController.js
@@ -1,0 +1,39 @@
+const fetch = require('node-fetch');
+const googleMapsController = {};
+
+// getLatLon will attempt to get the Latitude and Longitude based on
+// the address given
+// Required parameters:
+//    address: user's address
+//
+// Further infomration on the paramters and response:
+// https://developers.google.com/maps/documentation/geocoding/start
+googleMapsController.getLatLon = (req, res, next) => {
+  console.log('Invoked googleMapsController.getLatLon', req.query);
+  const { address } = req.query;
+  const API_URL = 'https://maps.googleapis.com/maps/api/geocode/json';
+  const params = `address=${address}&key=${process.env.GMAPS_KEY}`;
+  const URL = `${API_URL}?${params}`;
+  fetch(URL, {
+    method: 'GET',
+    redirect: 'follow',
+  })
+    .then(response => {
+      return response.json();
+    })
+    .then(data => {
+      console.log('getLatLon data', data);
+      res.locals.location = data;
+      return next();
+    })
+    .catch(error =>
+      next({
+        message: 'Error in googleMapsController.getLatLon middleware',
+        serverMessage: {
+          err: error,
+        },
+      })
+    );
+};
+
+module.exports = googleMapsController;

--- a/server/routes/googleMaps.js
+++ b/server/routes/googleMaps.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const googleMapsController = require('../controllers/googleMapsController');
+
+const router = express.Router();
+
+router.get('/', googleMapsController.getLatLon, (req, res) => {
+  // on success, res.locals.location will contain the Walk Score json blob
+  console.log('gmaps router.get /', res.locals.location);
+  res.status(res.statusCode).send(res.locals.location);
+});
+
+module.exports = router;

--- a/server/startup/routes.js
+++ b/server/startup/routes.js
@@ -6,6 +6,7 @@ const walkScore = require('../routes/walkScore');
 const yelp = require('../routes/yelp');
 const iqAir = require('../routes/iqAir');
 const healthyScore = require('../routes/healthyScore');
+const googleMaps = require('../routes/googleMaps');
 
 const baseUrl = process.env.BASE_URL;
 
@@ -21,6 +22,7 @@ module.exports = app => {
   app.use(`${baseUrl}/yelp`, yelp);
   app.use(`${baseUrl}/iqair`, iqAir);
   app.use(`${baseUrl}/healthyscore`, healthyScore);
+  app.use(`${baseUrl}/gmaps`, googleMaps);
 
   // app.get(`${baseUrl}/nope`, (req, res) => {
   //   res.status(200).json({ message: 'YOU DID IT!!' });


### PR DESCRIPTION
**server/startup/routes.js**
- Add route handler to for google maps api integration

**server/routes/googleMaps.js**
- Implements a single `GET` / request to get the user's latitude and longitude
- The request should send the user's address in the `address` parameter

**server/controllers/googleMapsController.js**
- `googleMapsController.getLatLon` will attempt to fetch the user's location (latitude and longitude) based on the given address in the query:
`{ address }`
- Currently there isn't any server-side address validation, so it will rely on the Google Maps Geocoding API to parse and return the geocoded location, which will be returned in `res.locals.location`.

**client/store/entities/mapEntity.js**
- Fix minor linter issue

**Testing**
- Perform a GET request like:
`http://localhost:3000/api/gmaps?address=1600 Main St Venice`